### PR TITLE
Add Power BI Theme Maker link to index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,6 +284,26 @@
             </div>
           </div>
         </div>
+
+        <div class="card" style="grid-column: 1 / -1; display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; align-items: center; margin-top: 1.5rem;">
+          <div class="card-img-container" style="height: auto; margin: 0; border: none; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
+            <img src="https://raw.githubusercontent.com/SRathinaGiri/PowerBIThemeMaker/main/screenshots/preview_page.png" alt="Power BI Theme Maker" class="card-img" style="object-fit: contain;">
+          </div>
+          <div>
+            <h3 style="font-size: 1.8rem; color: var(--accent);">Power BI Theme Maker</h3>
+            <p style="font-size: 1.1rem;">A single-file HTML application for generating, customizing, and validating Power BI JSON themes. Visually design themes, preview them in real-time, and export the resulting JSON configuration for direct import into Power BI.</p>
+
+            <div class="card-meta">
+              <span><strong>Status:</strong> Free & Open Source</span>
+              <span><strong>Hosting:</strong> GitHub</span>
+            </div>
+
+            <div class="card-actions" style="margin-top: 1.5rem;">
+               <a href="https://github.com/SRathinaGiri/PowerBIThemeMaker" class="btn btn-primary" target="_blank">View Project</a>
+               <a href="https://github.com/SRathinaGiri/PowerBIThemeMaker/blob/main/PowerBI%20Theme%20Maker.html" class="btn btn-secondary" target="_blank">View HTML Source</a>
+            </div>
+          </div>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
Added a new card in the Custom Visuals Gallery for the Power BI Theme Maker project. The card includes the description, an image, and links to the GitHub repository and the specific HTML file, fulfilling the user request.

---
*PR created automatically by Jules for task [15562638277800657016](https://jules.google.com/task/15562638277800657016) started by @SRathinaGiri*